### PR TITLE
only fire one coercion in inlined coerce

### DIFF
--- a/lib/Specio/Constraint/Role/Interface.pm
+++ b/lib/Specio/Constraint/Role/Interface.pm
@@ -329,14 +329,16 @@ sub inline_coercion {
     if ( $self->has_coercions ) {
         $source .= 'my $value = ' . $arg_name . ';';
         $arg_name = '$value';
+        $source .= $arg_name . ' = ';
         for my $coercion ( $self->coercions ) {
             $source
-                .= '$value = '
-                . $coercion->inline_coercion($arg_name) . ' if '
-                . $coercion->from->inline_check($arg_name) . ';';
+                .= '('
+                . $coercion->from->inline_check($arg_name) . ') ? ('
+                . $coercion->inline_coercion($arg_name) . ') : ';
 
             %env = ( %env, %{ $coercion->inline_environment } );
         }
+        $source .= $arg_name . ';';
     }
 
     $source .= $arg_name . '};';
@@ -357,14 +359,16 @@ sub inline_coercion_and_check {
     if ( $self->has_coercions ) {
         $source .= 'my $value = ' . $arg_name . ';';
         $arg_name = '$value';
+        $source .= $arg_name . ' = ';
         for my $coercion ( $self->coercions ) {
             $source
-                .= '$value = '
-                . $coercion->inline_coercion($arg_name) . ' if '
-                . $coercion->from->inline_check($arg_name) . ';';
+                .= '('
+                . $coercion->from->inline_check($arg_name) . ') ? ('
+                . $coercion->inline_coercion($arg_name) . ') : ';
 
             %env = ( %env, %{ $coercion->inline_environment } );
         }
+        $source .= $arg_name . ';';
     }
 
     my ( $assert, $assert_env ) = $self->inline_assert($arg_name);

--- a/t/coercion.t
+++ b/t/coercion.t
@@ -263,4 +263,37 @@ use Specio::Library::Builtins;
     );
 }
 
+{
+    my $str = declare(
+        'Str2',
+        parent => t('Str'),
+    );
+
+    coerce(
+        $str,
+        from   => t('Num'),
+        inline => sub {
+            return "$_[1] + 10";
+        },
+    );
+
+    coerce(
+        $str,
+        from   => t('Int'),
+        inline => sub {
+            return "$_[1] + 10";
+        },
+    );
+
+    my ( $source, $env ) = $str->inline_coercion('$_[0]');
+    my $code = eval_closure(
+        source      => "sub { $source }",
+        environment => $env,
+    );
+    is(
+        $code->(-10),
+        0,
+        'inlined coercion only fires one coercion',
+    );
+}
 done_testing();


### PR DESCRIPTION
Using an if condition for each coercion means that multiple coercions
may fire for once value coerce call.  It also is wasteful, as the type
checks will be performed for all coerce types rather than stopping once
it performs a coerce.

Switch to using ternaries rather than if conditions.