### PR TITLE
Fix by is_class_loaded function

### DIFF
--- a/lib/Specio/Helpers.pm
+++ b/lib/Specio/Helpers.pm
@@ -89,7 +89,10 @@ sub is_class_loaded {
     return 1 if exists $stash->{VERSION};
 
     foreach my $globref ( values %{$stash} ) {
-        return 1 if *{$globref}{CODE};
+        return 1
+          if ref \$globref eq 'GLOB'
+            ? *{$globref}{CODE}
+            : ref $globref; # const or sub ref
     }
 
     return 0;


### PR DESCRIPTION
is_class_loaded in Types::Standard has a flaw in it (see
<https://rt.cpan.org/Ticket/Display.html?id=123408>), because of
which it does not work with the CV-in-stash optimisation.  This module
borrows the code and has the same flaw, resulting in a ‘Not a GLOB
reference’ error.  This patch (practically the same as the one in
Type-Tiny’s RT queue) fixes the problem.

For more information on the optimisation, which
will likely be included in perl 5.28, see:
https://rt.perl.org/Ticket/Display.html?id=132252#txn-1500037