### PR TITLE
Fix docs for Specio::Declare::declare(inline=>...)

### DIFF
--- a/lib/Specio/Constraint/Intersection.pm
+++ b/lib/Specio/Constraint/Intersection.pm
@@ -98,7 +98,7 @@ sub _build_inline_generator {
             map { sprintf( '( %s )', $_->_inline_generator->( $_, $_[1] ) ) }
                 @{ $self->of }
         ) . ')';
-        }
+    }
 }
 
 sub _build_inline_environment {

--- a/lib/Specio/Constraint/Role/CanType.pm
+++ b/lib/Specio/Constraint/Role/CanType.pm
@@ -122,7 +122,7 @@ sub _word_list {
     return join ' and ', @items if @items == 2;
 
     my $final = pop @items;
-    my $list = join ', ', @items;
+    my $list  = join ', ', @items;
     $list .= ', and ' . $final;
 
     return $list;

--- a/lib/Specio/Constraint/Union.pm
+++ b/lib/Specio/Constraint/Union.pm
@@ -98,7 +98,7 @@ sub _build_inline_generator {
             map { sprintf( '( %s )', $_->_inline_generator->( $_, $_[1] ) ) }
                 @{ $self->of }
         ) . ')';
-        }
+    }
 }
 
 sub _build_inline_environment {

--- a/lib/Specio/Declare.pm
+++ b/lib/Specio/Declare.pm
@@ -467,14 +467,18 @@ type and all its parents. Typically, the easiest way to do this is to write a
 subroutine something like this:
 
   sub {
-      my $self = shift;
-      my $var  = shift;
+      my ($self, $var) = @_;
 
-      return $_[0]->parent->inline_check( $_[1] )
+      return $self->parent->inline_check( $var )
           . ' and more checking code goes here';
   }
 
-This parameter is mutually exclusive with the C<where> parameter.
+Or, more concisely:
+
+      sub { $_[0]->parent->inline_check( $_[1] )
+            . 'more code that checks $_[1]' }
+
+The C<inline> parameter is mutually exclusive with the C<where> parameter.
 
 =item * message_generator => sub { ... }
 

--- a/lib/Specio/Declare.pm
+++ b/lib/Specio/Declare.pm
@@ -151,7 +151,7 @@ sub object_does_type {
 
     my $tc = _make_tc(
         ( defined $name ? ( name => $name ) : () ),
-        role => ( defined $p{role} ? $p{role} : $name ),
+        role       => ( defined $p{role} ? $p{role} : $name ),
         type_class => 'Specio::Constraint::ObjectDoes',
     );
 
@@ -177,7 +177,7 @@ sub object_isa_type {
 
     my $tc = _make_tc(
         ( defined $name ? ( name => $name ) : () ),
-        class => ( defined $p{class} ? $p{class} : $name ),
+        class      => ( defined $p{class} ? $p{class} : $name ),
         type_class => 'Specio::Constraint::ObjectIsa',
     );
 
@@ -224,7 +224,7 @@ sub any_does_type {
 
     my $tc = _make_tc(
         ( defined $name ? ( name => $name ) : () ),
-        role => ( defined $p{role} ? $p{role} : $name ),
+        role       => ( defined $p{role} ? $p{role} : $name ),
         type_class => 'Specio::Constraint::AnyDoes',
     );
 
@@ -250,7 +250,7 @@ sub any_isa_type {
 
     my $tc = _make_tc(
         ( defined $name ? ( name => $name ) : () ),
-        class => ( defined $p{class} ? $p{class} : $name ),
+        class      => ( defined $p{class} ? $p{class} : $name ),
         type_class => 'Specio::Constraint::AnyIsa',
     );
 

--- a/lib/Specio/Library/Structured/Dict.pm
+++ b/lib/Specio/Library/Structured/Dict.pm
@@ -83,7 +83,7 @@ sub _structured_inline_generator {
     my @code = sprintf( '( %s )', $hashref->_inline_check($val) );
 
     for my $k ( sort keys %{ $args{kv} } ) {
-        my $p = $args{kv}{$k};
+        my $p      = $args{kv}{$k};
         my $access = sprintf( '%s->{%s}', $val, B::perlstring($k) );
 
         if ( !blessed($p) ) {

--- a/lib/Specio/Library/Structured/Tuple.pm
+++ b/lib/Specio/Library/Structured/Tuple.pm
@@ -133,7 +133,7 @@ sub _structured_inline_generator {
     }
 
     for my $i ( 0 .. $#of ) {
-        my $p = $of[$i];
+        my $p      = $of[$i];
         my $access = sprintf( '%s->[%d]', $val, $i );
 
         if ( !blessed($p) ) {

--- a/lib/Specio/OO.pm
+++ b/lib/Specio/OO.pm
@@ -168,7 +168,7 @@ EOF
 
     my $attrs = $class->_attrs;
     for my $name ( sort keys %{$attrs} ) {
-        my $attr = $attrs->{$name};
+        my $attr     = $attrs->{$name};
         my $key_name = defined $attr->{init_arg} ? $attr->{init_arg} : $name;
 
         if ( $attr->{required} ) {
@@ -314,7 +314,7 @@ sub clone {
     # to clone the coercions contained by a type in a way that doesn't lead to
     # circular clone (type clones coercions which in turn need to clone their
     # to/from types which in turn ...).
-    my $attrs = $self->_attrs;
+    my $attrs   = $self->_attrs;
     my %special = map { $_ => $attrs->{$_}{clone} }
         grep { $attrs->{$_}{clone} } keys %{$attrs};
 


### PR DESCRIPTION
Fixes #13.

I added both a `my () = @_` example and a `$_[]` example.

**Edit** 3091562 is the result of `tidyall -a` --- no hand changes.