### PR TITLE
Revert "Add a hideous hack to avoid breaking existing Moose tests"

### DIFF
--- a/lib/Specio/Declare.pm
+++ b/lib/Specio/Declare.pm
@@ -34,34 +34,6 @@ our @EXPORT = qw(
 sub import {
     my $package = shift;
 
-    # What the heck is this monstrosity?
-    #
-    # Moose version 2.0901 included a first pass at support for Specio. This
-    # was based on Specio c. 0.06 when Specio itself still used
-    # Moose. Unfortunately, recent changes to Specio broke this support and
-    # the Moose core needs updating.
-    #
-    # However, stable versions of Moose have since shipped with a test that
-    # attempts to test itself with Specio 0.07+. This was fine until I wanted
-    # to release a non-TRIAL Specio.
-    #
-    # Once that's out, anyone installing Specio will cause future attempts to
-    # install Moose to fail until Moose includes updated Specio support!
-    # Breaking Moose is not acceptable, thus this mess.
-    #
-    # Note that since Moose 2.1207 this test was renamed and the Specio tests
-    # actually run (and pass). We still need to leave this in here for quite
-    # some time. People should be able to install Specio and then install an
-    # older Moose indefinitely (or at least for a year or two).
-    if (   $ENV{HARNESS_ACTIVE}
-        && $0 =~ m{t[\\/]type_constraints[\\/]specio\.t$} ) {
-
-        require Test::More;
-        Test::More::plan( skip_all =>
-                'These tests will not pass with this version of Specio' );
-        exit 0;
-    }
-
     my $caller = caller();
 
     $package->export_to_level( 1, $package, @_ );


### PR DESCRIPTION
It is time to remove old hack for Moose tests.

This reverts commit 7d32c7e7c798c1cbb8c67b8db8ee1442b619b721.